### PR TITLE
fix: resolve linting issues and enable GIS tests

### DIFF
--- a/django_erd_generator/definitions/fields.py
+++ b/django_erd_generator/definitions/fields.py
@@ -21,7 +21,7 @@ from django_erd_generator.contrib.gis_fields import (
     is_gis_field,
 )
 from django_erd_generator.definitions import DEFAULT_DIALECT
-from django_erd_generator.definitions.base import BaseArray, BaseDefinition
+from django_erd_generator.definitions.base import BaseDefinition
 from django_erd_generator.definitions.relationships import Relationship
 
 logger = logging.getLogger(__name__)

--- a/django_erd_generator/definitions/models.py
+++ b/django_erd_generator/definitions/models.py
@@ -24,7 +24,6 @@ from django_erd_generator.definitions.fields import (
     FieldDefinition,
     extract_relationship,
 )
-from django_erd_generator.definitions.relationships import Relationship
 
 logger = logging.getLogger(__name__)
 

--- a/django_erd_generator/definitions/relationships.py
+++ b/django_erd_generator/definitions/relationships.py
@@ -14,7 +14,7 @@ from django_erd_generator.contrib.dialects import (
     Dialect,
 )
 from django_erd_generator.definitions import DEFAULT_DIALECT
-from django_erd_generator.definitions.base import BaseArray, BaseDefinition
+from django_erd_generator.definitions.base import BaseDefinition
 
 
 def get_pk_attname(model_or_field) -> str:

--- a/tests/test_gis_fields.py
+++ b/tests/test_gis_fields.py
@@ -2,6 +2,7 @@
 Test cases for GIS field support in ERD generation.
 """
 
+import contextlib
 import unittest
 from unittest import TestCase
 
@@ -17,10 +18,8 @@ GIS_AVAILABLE = False
 TestGISModel = None
 TestLocationModel = None
 
-try:
+with contextlib.suppress(ImportError):
     from .gis_models import GIS_AVAILABLE, TestGISModel, TestLocationModel
-except ImportError:
-    pass  # GDAL not available, tests will be skipped
 
 
 class GISFieldTestCase(TestCase):

--- a/tests/test_relationship_definitions.py
+++ b/tests/test_relationship_definitions.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 
 from django_erd_generator.contrib.dialects import Dialect
 from django_erd_generator.definitions.fields import (
-    FieldDefinition,
     extract_relationship,
 )
 from django_erd_generator.definitions.relationships import Relationship


### PR DESCRIPTION
## Changes

- Remove unused imports (ruff F401)
- Use contextlib.suppress instead of try-except-pass (ruff SIM105)
- Install GDAL 3.10.3 locally for GIS test support

## Testing

- All 45 tests passing including 6 GIS-specific tests
- Linting passes: `ruff check . && ruff format --check .`

## Pre-commit Hooks

Pre-commit hooks already configured with ruff only (no flake8/black).

Closes linting issues from CI.