### PR TITLE
fix: missing middleware comma, tox envlist, private attrs, git error handling, package exports

### DIFF
--- a/django_erd_generator/__init__.py
+++ b/django_erd_generator/__init__.py
@@ -1,0 +1,6 @@
+"""Django ERD Generator package."""
+
+from django_erd_generator.contrib.dialects import Dialect
+from django_erd_generator.utils.data_dictionary import DataDictionary
+
+__all__ = ["Dialect", "DataDictionary"]

--- a/django_erd_generator/utils/data_dictionary.py
+++ b/django_erd_generator/utils/data_dictionary.py
@@ -161,14 +161,14 @@ class DataDictionary:
         doc_string = doc_string.strip()
 
         fields = []
-        for field in model._fields:
+        for field in model.fields:
             meta = field.django_field.__dict__
             related = meta.get("related_model")
             fields.append(
                 {
                     "pk": "✓" if meta.get("primary_key") else "",
-                    "field_name": field._col_name,
-                    "data_type": f"`{field._data_type['data_type'].replace('_', ' ') or ''}`",
+                    "field_name": field.col_name,
+                    "data_type": f"`{field.data_type['data_type'].replace('_', ' ')}`",
                     "related_model": f"[{related.__name__}](#{related.__name__})"
                     if related and hasattr(related, "__name__")
                     else "",

--- a/django_erd_generator/utils/git.py
+++ b/django_erd_generator/utils/git.py
@@ -27,10 +27,13 @@ def get_git_commit() -> str:
         >>> commit = get_git_commit()
         >>> print(f"Generated from commit: {commit}")
     """
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.strip()
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return ""

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,7 +25,7 @@ if not settings.configured:
         MIDDLEWARE=(
             "django.middleware.common.CommonMiddleware",
             "django.contrib.sessions.middleware.SessionMiddleware",
-            "django.contrib.auth.middleware.AuthenticationMiddleware"
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
             "django.contrib.messages.middleware.MessageMiddleware",
         ),
         INSTALLED_APPS=(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, py313
+envlist = py39, py310, py311, py312, py313
 
 [testenv]
 deps =


### PR DESCRIPTION
Cleans up issues from code audit:

- Missing comma in MIDDLEWARE tuple (implicit string concatenation bug)
- tox.ini includes py38 but pyproject.toml requires >=3.9
- Private attribute access in DataDictionary.render_model
- git.py lacks error handling for non-repo contexts
- Empty package __init__.py